### PR TITLE
Add conditional clipboard configuration for macOS

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -40,15 +40,20 @@ vim.opt.backup = false
 
 -- Configuração para clipboard usando win32yank
 vim.opt.clipboard = "unnamedplus"
--- vim.g.clipboard = {
--- 	name = "win32yank",
--- 	copy = {
--- 		["+"] = "win32yank.exe -i --crlf",
--- 		["*"] = "win32yank.exe -i --crlf",
--- 	},
--- 	paste = {
--- 		["+"] = "win32yank.exe -o --lf",
--- 		["*"] = "win32yank.exe -o --lf",
--- 	},
--- 	cache_enabled = 0,
--- }
+
+if vim.fn.has("macunix") == 0 then
+	vim.g.clipboard = {
+		name = "win32yank",
+		copy = {
+			["+"] = "win32yank.exe -i --crlf",
+			["*"] = "win32yank.exe -i --crlf",
+		},
+		paste = {
+			["+"] = "win32yank.exe -o --lf",
+			["*"] = "win32yank.exe -o --lf",
+		},
+		cache_enabled = 0,
+	}
+end
+
+


### PR DESCRIPTION
## Summary
- prevent the win32yank clipboard setup from loading on macOS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684975d4cfc4832098fce617f22062b6