### PR TITLE
Add keymap groups and which-key integration

### DIFF
--- a/lua/core/keymaps/basic_spec.lua
+++ b/lua/core/keymaps/basic_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Basics",
+        group_prefix = "<leader>b",
+        mappings = {
 		{ "n", "<C-a>", "<Cmd>keepjumps normal! ggVG<CR>", "Selecionar todo o texto" },
 		{ "n", "<C-s>", "<Cmd>w<CR>", "Salvar arquivo" },
 		{ "n", "<C-q>", "<Cmd>q<CR>", "Sair" },

--- a/lua/core/keymaps/codecompanion_spec.lua
+++ b/lua/core/keymaps/codecompanion_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Code Companion",
+        group_prefix = "<leader>c",
+        mappings = {
 		{
 			"n",
 			"<leader>cc",

--- a/lua/core/keymaps/command_spec.lua
+++ b/lua/core/keymaps/command_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Command",
+        group_prefix = "<leader>:",
+        mappings = {
 		{ "c", "<C-v>", "<C-r>+", "Colar do clipboard" },
 	},
 }

--- a/lua/core/keymaps/comments_spec.lua
+++ b/lua/core/keymaps/comments_spec.lua
@@ -1,0 +1,7 @@
+return {
+    group_name = "Refactor",
+    group_prefix = "<leader>r",
+    mappings = {
+        { "n", "<leader>rc", "<Cmd>RemoveComments<CR>", "Remove all comments" },
+    },
+}

--- a/lua/core/keymaps/diagnostics_spec.lua
+++ b/lua/core/keymaps/diagnostics_spec.lua
@@ -28,7 +28,9 @@ end
 
 -- Mapeia a tecla <leader>d para alternar diagnósticos
 return {
-	mappings = {
+        group_name = "Diagnostics",
+        group_prefix = "<leader>d",
+        mappings = {
 		{
 			"n",
 			"<leader>d",

--- a/lua/core/keymaps/diffview_spec.lua
+++ b/lua/core/keymaps/diffview_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Diffview",
+        group_prefix = "<leader>d",
+        mappings = {
 		-- Comandos principais do Diffview
 		{
 			"n",

--- a/lua/core/keymaps/engine.lua
+++ b/lua/core/keymaps/engine.lua
@@ -44,6 +44,10 @@ local function normalize(ev)
 	return { event = ev }
 end
 
+function M.get_specs()
+    return specs
+end
+
 function M.setup()
 	for _, spec in ipairs(specs) do
 		if spec.event then

--- a/lua/core/keymaps/gitsigns_spec.lua
+++ b/lua/core/keymaps/gitsigns_spec.lua
@@ -1,0 +1,14 @@
+return {
+    group_name = "Gitsigns",
+    group_prefix = "<leader>g",
+    event = "BufReadPre",
+    mappings = {
+        { "n", "]h", function() require("gitsigns").next_hunk() end, "Next Hunk" },
+        { "n", "[h", function() require("gitsigns").prev_hunk() end, "Prev Hunk" },
+        { "n", "<leader>gs", function() require("gitsigns").stage_hunk() end, "Stage Hunk" },
+        { "n", "<leader>gu", function() require("gitsigns").undo_stage_hunk() end, "Undo Stage Hunk" },
+        { "n", "<leader>gr", function() require("gitsigns").reset_hunk() end, "Reset Hunk" },
+        { "n", "<leader>gp", function() require("gitsigns").preview_hunk() end, "Preview Hunk" },
+        { "n", "<leader>gb", function() require("gitsigns").blame_line() end, "Blame Line" },
+    },
+}

--- a/lua/core/keymaps/hardtime_spec.lua
+++ b/lua/core/keymaps/hardtime_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Hardtime",
+        group_prefix = "<leader>h",
+        mappings = {
 		{ "n", "<leader>ht", "<cmd>:Hardtime toggle<CR>", "Habilita/Desabilita o Hardtime.nvim" },
 	},
 }

--- a/lua/core/keymaps/insert_spec.lua
+++ b/lua/core/keymaps/insert_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Insert",
+        group_prefix = "<leader>i",
+        mappings = {
 		{ "i", "<C-h>", "<Left>", "Mover cursor para esquerda" },
 		{ "i", "<C-l>", "<Right>", "Mover cursor para direita" },
 		{ "i", "<C-j>", "<Down>", "Mover cursor para baixo" },

--- a/lua/core/keymaps/lazygit_spec.lua
+++ b/lua/core/keymaps/lazygit_spec.lua
@@ -1,0 +1,10 @@
+return {
+    group_name = "Git",
+    group_prefix = "<leader>g",
+    mappings = {
+        { "n", "<leader>gg", "<Cmd>LazyGit<CR>", "Open LazyGit" },
+        { "n", "<leader>gc", "<Cmd>LazyGitCurrentFile<CR>", "LazyGit Current File" },
+        { "n", "<leader>gf", "<Cmd>LazyGitFilter<CR>", "LazyGit Filter" },
+        { "n", "<leader>gw", "<Cmd>GitWorkflow<CR>", "Git Workflow (LazyGit + Diffview)" },
+    },
+}

--- a/lua/core/keymaps/lsp_spec.lua
+++ b/lua/core/keymaps/lsp_spec.lua
@@ -1,6 +1,8 @@
 return {
-	event = "LspAttach", -- Será aplicado quando um LSP se conectar
-	mappings = {
+        event = "LspAttach", -- Será aplicado quando um LSP se conectar
+        group_name = "LSP",
+        group_prefix = "<leader>l",
+        mappings = {
 		-- Atalhos adicionais / overrides (os que você realmente precisa customizar)
 		{ "n", "gd", vim.lsp.buf.definition, "Go to definition" },
 		{ "n", "gD", vim.lsp.buf.declaration, "Go to declaration" },

--- a/lua/core/keymaps/movement_spec.lua
+++ b/lua/core/keymaps/movement_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Movement",
+        group_prefix = "<leader>m",
+        mappings = {
 		-- [[ Movimentos + Centralização ]]
 		{ "n", "w", "wzz", "Próxima palavra e centralizar" },
 		{ "n", "b", "bzz", "Palavra anterior e centralizar" },

--- a/lua/core/keymaps/neotest_spec.lua
+++ b/lua/core/keymaps/neotest_spec.lua
@@ -1,0 +1,14 @@
+return {
+    group_name = "Tests",
+    group_prefix = "<leader>j",
+    mappings = {
+        { "n", "<leader>jw", "<cmd>lua require('neotest').run.run({ jestCommand = 'pnpx jest --watch ' })<cr>", "Neotest Watch" },
+        { "n", "<leader>js", "<cmd>lua require('neotest').run.stop()<cr>", "Neotest Stop" },
+        { "n", "<leader>jr", "<cmd>lua require('neotest').run.run()<cr>", "Neotest Run" },
+        { "n", "<leader>jf", "<cmd>lua require('neotest').run.run(vim.fn.expand('%'))<cr>", "Neotest Run File" },
+        { "n", "<leader>jo", "<cmd>lua require('neotest').output.open()<cr>", "Neotest Output" },
+        { "n", "<leader>ju", "<cmd>lua require('neotest').summary.toggle()<cr>", "Neotest Summary" },
+        { "n", "<leader>jp", "<cmd>lua require('neotest').jump.prev({status = 'failed'})<cr>", "Neotest Jump Prev Failed" },
+        { "n", "<leader>jn", "<cmd>lua require('neotest').jump.next({status = 'failed'})<cr>", "Neotest Jump Next Failed" },
+    },
+}

--- a/lua/core/keymaps/neotree_spec.lua
+++ b/lua/core/keymaps/neotree_spec.lua
@@ -1,0 +1,9 @@
+return {
+    group_name = "Explorer",
+    group_prefix = "<leader>e",
+    mappings = {
+        { "n", "<leader>e", "<Cmd>Neotree toggle reveal<CR>", "Neo-tree Toggle/Reveal" },
+        { "n", "<leader>fe", "<Cmd>Neotree filesystem focus<CR>", "Neo-tree Focus Filesystem" },
+        { "n", "<leader>fb", "<Cmd>Neotree buffers focus<CR>", "Neo-tree Focus Buffers" },
+    },
+}

--- a/lua/core/keymaps/spectre_spec.lua
+++ b/lua/core/keymaps/spectre_spec.lua
@@ -1,4 +1,6 @@
 return {
+  group_name = "Spectre",
+  group_prefix = "<leader>s",
   mappings = {
     {
       "n",

--- a/lua/core/keymaps/telescope_spec.lua
+++ b/lua/core/keymaps/telescope_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Telescope",
+        group_prefix = "<leader>f",
+        mappings = {
 		{
 			"n",
 			"<leader>ff",

--- a/lua/core/keymaps/terminal_spec.lua
+++ b/lua/core/keymaps/terminal_spec.lua
@@ -1,7 +1,9 @@
 return {
-	event = "TermOpen",
-	buffer_local = true,
-	mappings = {
+        event = "TermOpen",
+        buffer_local = true,
+        group_name = "Terminal",
+        group_prefix = "<leader>t",
+        mappings = {
 		{ "t", "<Esc>", "<C-\\><C-n>", "Sair do modo terminal" },
 		{ "t", "<C-h>", "<C-\\><C-n><C-w>h", "Janela à esquerda" },
 		{ "t", "<C-j>", "<C-\\><C-n><C-w>j", "Janela abaixo" },

--- a/lua/core/keymaps/trouble_spec.lua
+++ b/lua/core/keymaps/trouble_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Trouble",
+        group_prefix = "<leader>x",
+        mappings = {
 		{
 			"n",
 			"<leader>xx",

--- a/lua/core/keymaps/visual_spec.lua
+++ b/lua/core/keymaps/visual_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Visual",
+        group_prefix = "<leader>v",
+        mappings = {
 		-- Desindentar/indentar mantendo seleção
 		{ "v", "<", "<gv", "Des‑indentar e manter seleção" },
 		{ "v", ">", ">gv", "Indentar e manter seleção" },

--- a/lua/core/keymaps/window_spec.lua
+++ b/lua/core/keymaps/window_spec.lua
@@ -1,5 +1,7 @@
 return {
-	mappings = {
+        group_name = "Windows",
+        group_prefix = "<leader>w",
+        mappings = {
 		-- Criar splits
 		{ "n", "<leader>ws", "<Cmd>split<CR>", "Dividir horizontalmente", { nowait = true } },
 		{ "n", "<leader>wv", "<Cmd>vsplit<CR>", "Dividir verticalmente", { nowait = true } },

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -145,9 +145,6 @@ return {
 			},
 		})
 
-		vim.keymap.set("n", "<Leader>e", "<Cmd>Neotree toggle reveal<CR>", { desc = "Neo-tree: Toggle/Reveal" })
-		vim.keymap.set("n", "<Leader>fe", "<Cmd>Neotree filesystem focus<CR>", { desc = "Neo-tree: Focus Filesystem" })
-		vim.keymap.set("n", "<Leader>fb", "<Cmd>Neotree buffers focus<CR>", { desc = "Neo-tree: Focus Buffers" })
-		-- vim.keymap.set("n", "<Leader>fg", "<Cmd>Neotree git_status focus<CR>", { desc = "Neo-tree: Focus Git Status" })
+-- Keymaps handled by core keymap specs
 	end,
 }

--- a/lua/plugins/neotest.lua
+++ b/lua/plugins/neotest.lua
@@ -17,12 +17,7 @@ return {
 					cwd = function(path)
 						return vim.fn.getcwd()
 					end,
-					vim.api.nvim_set_keymap(
-						"n",
-						"<leader>jw",
-						"<cmd>lua require('neotest').run.run({ jestCommand = 'pnpx jest --watch ' })<cr>",
-						{}
-					),
+                                        -- keymaps provided by core keymap specs
 				}),
 				require("neotest-java")({
 					runner = "gradle",
@@ -34,11 +29,5 @@ return {
 			},
 		})
 	end,
-	vim.api.nvim_set_keymap("n", "<leader>js", "<cmd>lua require('neotest').run.stop()<cr>", {}),
-	vim.api.nvim_set_keymap("n", "<leader>jr", "<cmd>lua require('neotest').run.run()<cr>", {}),
-	vim.api.nvim_set_keymap("n", "<leader>jf", "<cmd>lua require('neotest').run.run(vim.fn.expand('%'))<cr>", {}),
-	vim.api.nvim_set_keymap("n", "<leader>jo", "<cmd>lua require('neotest').output.open()<cr>", {}),
-	vim.api.nvim_set_keymap("n", "<leader>ju", "<cmd>lua require('neotest').summary.toggle()<cr>", {}),
-	vim.api.nvim_set_keymap("n", "<leader>jp", "<cmd>lua require('neotest').jump.prev({status = 'failed'})<cr>", {}),
-	vim.api.nvim_set_keymap("n", "<leader>jn", "<cmd>lua require('neotest').jump.next({status = 'failed'})<cr>", {}),
+        -- keymaps provided by core keymap specs
 }

--- a/lua/plugins/trouble.lua
+++ b/lua/plugins/trouble.lua
@@ -11,9 +11,5 @@ return {
 				information = "ℹ️",
 			},
 		})
-		-- Atalho para abrir o painel Trouble
-		vim.keymap.set("n", "<leader>xx", function()
-			require("trouble").toggle()
-		end)
-	end,
+        end,
 }

--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -1,0 +1,18 @@
+return {
+    "folke/which-key.nvim",
+    event = "VeryLazy",
+    config = function(_, opts)
+        local wk = require("which-key")
+        wk.setup(opts or {})
+
+        local specs = require("core.keymaps.engine").get_specs()
+        local registrations = {}
+        for _, spec in ipairs(specs) do
+            if spec.group_name and spec.group_prefix then
+                table.insert(registrations, { spec.group_prefix, group = spec.group_name })
+            end
+        end
+
+        wk.register(registrations)
+    end,
+}

--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -5,6 +5,7 @@ return {
         local wk = require("which-key")
         wk.setup(opts or {})
 
+        -- Register keymap groups automatically from core specs
         local specs = require("core.keymaps.engine").get_specs()
         local registrations = {}
         for _, spec in ipairs(specs) do
@@ -13,6 +14,7 @@ return {
             end
         end
 
-        wk.register(registrations)
+        -- Use the new which-key v2 format for groups
+        wk.register(registrations, { mode = "n" })
     end,
 }


### PR DESCRIPTION
## Summary
- create keymap specs for multiple plugins and register groups with which-key
- expose specs from the keymap engine for use by which-key
- remove redundant mappings from the neotest plugin

## Testing
- `nvim --headless +qa` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684988df2c488320833756401e4e6b4e