### PR TITLE
Fix blink.cmp setup

### DIFF
--- a/lua/plugins/blink.lua
+++ b/lua/plugins/blink.lua
@@ -66,7 +66,7 @@ return {
                 preset = "luasnip",
             },
             sources = {
-                default = { "lsp", "path", "snippets", "buffer", "conventional_commits", "avante", "env", "nerdfont" },
+                default = { "lsp", "path", "luasnip", "buffer", "conventional_commits", "avante", "env", "nerdfont" },
                 providers = {
                     lsp = {
                         name = "LSP",
@@ -108,14 +108,9 @@ return {
                         score_offset = 15,
                         opts = { insert = true },
                     },
-                    snippets = {
-                        name = "Snippets",
-                        module = "blink.cmp.sources.snippets",
-                        opts = {
-                            search_paths = {
-                                vim.fn.stdpath("config") .. "/snippets",
-                            },
-                        },
+                    luasnip = {
+                        name = "LuaSnip",
+                        module = "blink.cmp.sources.luasnip",
                     },
                 },
             },
@@ -125,7 +120,6 @@ return {
                     border = "rounded",
                 },
             },
-            opts_extend = { "sources.default" },
         })
 
         local luasnip_status, _ = pcall(require, "luasnip")


### PR DESCRIPTION
## Summary
- update completion provider name to `luasnip`
- remove obsolete search paths option
- drop deprecated `opts_extend`

## Testing
- `stylua --version` *(fails: command not found)*
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f788e26483209cb34cca18cb49be