### PR TITLE
Fix blink snippet provider

### DIFF
--- a/lua/plugins/blink.lua
+++ b/lua/plugins/blink.lua
@@ -66,7 +66,7 @@ return {
                 preset = "luasnip",
             },
             sources = {
-                default = { "lsp", "path", "luasnip", "buffer", "conventional_commits", "avante", "env", "nerdfont" },
+                default = { "lsp", "path", "snippets", "buffer", "conventional_commits", "avante", "env", "nerdfont" },
                 providers = {
                     lsp = {
                         name = "LSP",


### PR DESCRIPTION
## Summary
- update `blink.cmp` config to use `snippets` source

## Testing
- `nvim --headless -c 'qa'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fb49b96c83209093b083060e2f63