### PR TITLE
Update which-key group spec

### DIFF
--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -7,6 +7,8 @@ return {
 
         local specs = require("core.keymaps.engine").get_specs()
         local groups = {}
+
+        -- collect group names by their prefixes
         for _, spec in ipairs(specs) do
             if spec.group_name and spec.group_prefix then
                 groups[spec.group_prefix] = groups[spec.group_prefix] or {}
@@ -14,8 +16,12 @@ return {
             end
         end
 
+        -- register the groups using the new which-key spec
+        local registrations = {}
         for prefix, names in pairs(groups) do
-            wk.register({ [prefix] = { name = table.concat(names, ", ") } })
+            table.insert(registrations, { prefix, group = table.concat(names, ", ") })
         end
+
+        wk.register(registrations)
     end,
 }

--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -20,11 +20,12 @@ return {
         local registrations = {}
         for prefix, names in pairs(groups) do
             table.insert(registrations, {
-                prefix = prefix,
+                prefix,
                 group = table.concat(names, ", "),
             })
         end
 
-        wk.register(registrations)
+        -- `wk.add` is used for the new specification
+        wk.add(registrations)
     end,
 }

--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -19,7 +19,10 @@ return {
         -- register the groups using the new which-key spec
         local registrations = {}
         for prefix, names in pairs(groups) do
-            table.insert(registrations, { prefix, group = table.concat(names, ", ") })
+            table.insert(registrations, {
+                prefix = prefix,
+                group = table.concat(names, ", "),
+            })
         end
 
         wk.register(registrations)


### PR DESCRIPTION
## Summary
- update which-key registration to use the new mapping spec

## Testing
- `npx --yes stylua lua/plugins/which-key.lua` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849fd345e348320a34d894f9a86ff13