### PR TITLE
Add arrow.nvim plugin

### DIFF
--- a/lua/core/keymaps/arrow_spec.lua
+++ b/lua/core/keymaps/arrow_spec.lua
@@ -1,0 +1,10 @@
+return {
+    group_name = "Arrow",
+    group_prefix = "<leader>a",
+    mappings = {
+        { "n", "<leader>aa", "<cmd>ArrowMark<CR>", "Adicionar marca Arrow" },
+        { "n", "<leader>al", "<cmd>ArrowMenu<CR>", "Abrir menu Arrow" },
+        { "n", "<leader>an", "<cmd>ArrowNext<CR>", "Próxima marca" },
+        { "n", "<leader>ap", "<cmd>ArrowPrev<CR>", "Marca anterior" },
+    },
+}

--- a/lua/plugins/arrow.lua
+++ b/lua/plugins/arrow.lua
@@ -1,0 +1,11 @@
+return {
+    "otavioschwanck/arrow.nvim",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    event = "VeryLazy",
+    config = function()
+        require("arrow").setup({
+            show_icons = true,
+            leader_key = "<leader>a",
+        })
+    end,
+}


### PR DESCRIPTION
## Summary
- add arrow.nvim plugin for quick navigation
- map Arrow commands under `<leader>a`

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0291b03c832085aa87d585ee8234