### PR TITLE
Add keymaps for multiple ToggleTerm windows

### DIFF
--- a/lua/core/keymaps/toggleterm_spec.lua
+++ b/lua/core/keymaps/toggleterm_spec.lua
@@ -1,7 +1,32 @@
 return {
 	group_name = "ToggleTerm",
 	group_prefix = "<leader>T",
-	mappings = {
-		{ "n", "<leader>tt", "<cmd>ToggleTerm<CR>", "Abrir Terminal" },
-	},
+        mappings = {
+                { "n", "<leader>tt", "<cmd>ToggleTerm<CR>", "Abrir Terminal" },
+                {
+                        "n",
+                        "<leader>tv",
+                        "<cmd>ToggleTerm direction=vertical<CR>",
+                        "Abrir Terminal Vertical",
+                },
+                {
+                        "n",
+                        "<leader>th",
+                        "<cmd>ToggleTerm direction=horizontal<CR>",
+                        "Abrir Terminal Horizontal",
+                },
+                { "n", "<leader>t2", "<cmd>2ToggleTerm<CR>", "Abrir Segundo Terminal" },
+                {
+                        "n",
+                        "<leader>t2v",
+                        "<cmd>2ToggleTerm direction=vertical<CR>",
+                        "Segundo Terminal Vertical",
+                },
+                {
+                        "n",
+                        "<leader>t2h",
+                        "<cmd>2ToggleTerm direction=horizontal<CR>",
+                        "Segundo Terminal Horizontal",
+                },
+        },
 }

--- a/lua/plugins/toggleterm.lua
+++ b/lua/plugins/toggleterm.lua
@@ -3,11 +3,11 @@ return {
 	version = "*",
 	event = "VeryLazy",
 	config = function()
-	require("toggleterm").setup({
-		size = 20,
-		open_mapping = [[<c-\>]],
-		shade_terminals = true,
-		direction = "float",
-	})
+        require("toggleterm").setup({
+                size = 20,
+                open_mapping = [[<c-\>]],
+                shade_terminals = true,
+                direction = "horizontal",
+        })
 	end,
 }


### PR DESCRIPTION
## Summary
- make ToggleTerm default to horizontal layout
- add mappings for opening a second terminal in vertical or horizontal splits

## Testing
- `npx stylua lua/plugins/toggleterm.lua lua/core/keymaps/toggleterm_spec.lua` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6855715697ac8320a470f8ac43b09366